### PR TITLE
Added - cffi as an install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,21 +5,26 @@ Part of PyZFSCore.
 Copyright 2013 Trevor Joynson
 
 """
+from setuptools import setup, Extension
 
-from setuptools import setup
-
-import pyzfscore
-import pyzfscore.libzfs
-import pyzfscore.libnvpair
+libzfs_ext = Extension(
+    name='libzfs',
+    define_macros=[('NDEBUG', 1), ('HAVE_IOCTL_IN_SYS_IOCTL_H', 1)],
+    libraries=['nvpair', 'zfs', 'zpool'],
+    sources=['pyzfscore/__pycache__/_cffi__x8618e7c5xe2b6f166.c'],
+    include_dirs=['/usr/include/libzfs', '/usr/include/libspl']
+)
 
 setup(
     name='pyzfscore',
     version='0.0.1',
     description='ZFS CFFI wrapper.',
     license='GPL3',
-    maintainer='Trevor Joynson',
-    maintainer_email='github@skywww.net',
-    url='http://github.com/akatrevorjay/pyzfscore',
+    author='Trevor Joynson',
+    author_email='github@skywww.net',
+    maintainer='Ben Cole',
+    maintainer_email='wengole@gmail.com',
+    url='http://github.com/wengole/pyzfscore',
     packages=[
         'pyzfscore',
         'pyzfscore.libzfs',
@@ -29,7 +34,6 @@ setup(
     install_requires=['cffi'],
     zip_safe=False,
     ext_modules=[
-        pyzfscore.libzfs.ffi.verifier.get_extension(),
-        pyzfscore.libnvpair.ffi.verifier.get_extension(),
+        libzfs_ext
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,16 @@ setup(
     maintainer='Trevor Joynson',
     maintainer_email='github@skywww.net',
     url='http://github.com/akatrevorjay/pyzfscore',
-    packages=['pyzfscore',
-              'pyzfscore.libzfs',
-              'pyzfscore.flufl',
-              'pyzfscore.flufl.enum',
-              ],
-    #use_2to3=True,
-
+    packages=[
+        'pyzfscore',
+        'pyzfscore.libzfs',
+        'pyzfscore.flufl',
+        'pyzfscore.flufl.enum',
+    ],
+    install_requires=['cffi'],
     zip_safe=False,
-    ext_modules=[pyzfscore.libzfs.ffi.verifier.get_extension(),
-                 pyzfscore.libnvpair.ffi.verifier.get_extension(),
-                 ],
+    ext_modules=[
+        pyzfscore.libzfs.ffi.verifier.get_extension(),
+        pyzfscore.libnvpair.ffi.verifier.get_extension(),
+    ],
 )


### PR DESCRIPTION
This makes installing pyzfscore (using pip for example) easier as it will fetch its requirements